### PR TITLE
add ansible required `FilterModule` class

### DIFF
--- a/jinja2_strcase/jinja2_strcase.py
+++ b/jinja2_strcase/jinja2_strcase.py
@@ -101,3 +101,17 @@ class StrcaseExtension(Extension):
         environment.filters['to_screaming_snake'] = to_screaming_snake
         environment.filters['to_delimited'] = to_delimited
         environment.filters['to_screaming_delimited'] = to_screaming_delimited
+
+# needed for use as an ansible filter
+class FilterModule(object):
+    def filters(self):
+        return {
+            'to_camel': to_camel,
+            'to_lower_camel': to_lower_camel,
+            'to_kebab': to_kebab,
+            'to_screaming_kebab': to_screaming_kebab,
+            'to_snake': to_snake,
+            'to_screaming_snake': to_screaming_snake,
+            'to_delimited': to_delimited,
+            'to_screaming_delimited': to_screaming_delimited,
+        }


### PR DESCRIPTION
added required class for ansible to recognize this as a filter, allowing
it to be used in playbooks.